### PR TITLE
Fix downloadUrl when repo is private

### DIFF
--- a/src/components/utils.js
+++ b/src/components/utils.js
@@ -1,4 +1,5 @@
 import request from 'request';
+import config from '../config';
 
 export function asyncHandler(handler) {
   return function(req, res, next) {
@@ -39,7 +40,16 @@ export function asyncHandler(handler) {
 
 export function getRedirect(url) {
   return new Promise(function(resolve, reject) {
-    request({ url: url, followRedirect: false }, function(err, res) {
+    let options = {
+      url: url,
+      followRedirect: false,
+      headers: {
+        'Authorization': `token ${config.github.token}`,
+        'Accept': 'application/octet-stream',
+        'User-Agent': config.github.api.headers['user-agent']
+      }
+    };
+    request(options, function(err, res, body) {
       if (err) {
         reject(err);
       } else {

--- a/src/controllers/download.js
+++ b/src/controllers/download.js
@@ -38,9 +38,11 @@ export async function latest(req, res) {
   asset = latestRelease.assets.find(a => a.name.match(pattern));
   if (!asset) throw new Error(`404:No asset found that matches '${pattern}'.`);
 
-  let downloadUrl = asset.browser_download_url;
+  let downloadUrl = null;
   if (config.privateRepo) {
-    downloadUrl = await getRedirect(downloadUrl);
+    downloadUrl = await getRedirect(asset.url);
+  } else {
+    downloadUrl = asset.browser_download_url;
   }
 
   res.redirect(301, downloadUrl);

--- a/src/controllers/update.js
+++ b/src/controllers/update.js
@@ -20,9 +20,11 @@ export async function darwin(req, res) {
     const asset = latestRelease.assets.find(a => a.name.match(config.patterns.darwin.zip));
     if (!asset) throw new Error(`404:No asset found that matches '${config.patterns.darwin.zip}'.`);
 
-    let downloadUrl = asset.browser_download_url;
+    let downloadUrl = null;
     if (config.privateRepo) {
-      downloadUrl = await getRedirect(downloadUrl);
+      downloadUrl = await getRedirect(asset.url);
+    } else {
+      downloadUrl = asset.browser_download_url;
     }
 
     res.json({
@@ -48,9 +50,11 @@ export async function win32_portable(req, res) {
   const zipAsset = latestRelease.assets.find(a => a.name.match(config.patterns.win32.zip));
   if (!zipAsset) throw new Error(`404:No asset found that matches '${config.patterns.win32.zip}'.`);
 
-  let downloadUrl = zipAsset.browser_download_url;
+  let downloadUrl = null;
   if (config.privateRepo) {
-    downloadUrl = await getRedirect(downloadUrl);
+    downloadUrl = await getRedirect(zipAsset.url);
+  } else {
+    downloadUrl = zipAsset.browser_download_url;
   }
 
   res.json({
@@ -107,9 +111,11 @@ export async function linux(req, res) {
   const asset = latestRelease.assets.find(a => a.name.includes(pkg) && a.name.includes(arch));
   if (!asset) throw new Error(`404:No asset found for pkg '${pkg}' and arch '${arch}'.`);
 
-  let downloadUrl = asset.browser_download_url;
+  let downloadUrl = null;
   if (config.privateRepo) {
-    downloadUrl = await getRedirect(downloadUrl);
+    downloadUrl = await getRedirect(asset.url);
+  } else {
+    downloadUrl = asset.browser_download_url;
   }
 
   res.json({


### PR DESCRIPTION
This is probably poor Github etiquette, because I've tested little of this code, but I wanted to let @Aluxian and anyone else who might use this repo to be aware of a bug when using this with private repos (because I've spent about 5 frustrating hours figuring this out).

First, for reference: http://stackoverflow.com/questions/25923939/how-do-i-download-binary-files-of-a-github-release/35280061#35280061

The old code was passing in `asset.browser_download_url` instead of `asset.url` to `getRedirect` in order to find the AWS url for the asset. This is incorrect. I've fixed that.

Unfortunately, I don't currently have time to test all the code paths. The one I've tested is the `/update/darwin` path. The others are similar, so it _should_ work (famous last words).

Also, I do not know whether `win32_file` in the update controller needs to be changed. It's quite different than the others.

To confirm this fix yourself:
* Get a private repo with a tag and a release to that tag. Add assets for squirrel-update-server to find.
* Configure config.js with the details. `privateRepo` is true.
* Visit `http://localhost:3000/update/darwin?version=1.0.0` with whatever value for `version` you used in your release.

Before the fix, the "url" key was not present, after the fix, it is present.