### PR TITLE
fix issue where channel downloads would not work

### DIFF
--- a/src/controllers/update.js
+++ b/src/controllers/update.js
@@ -73,8 +73,10 @@ export async function win32_file(req, res) {
   const fileName = req.params.file;
   if (!fileName) throw new BadRequestError(`Invalid file '${fileName}'.`);
 
+  const channelStr = `(${config.channels.join('|')})`;
+  const versionRegex = new RegExp(`\\d+\\.\\d+\\.\\d+(-${channelStr}(-\\d+)?)?`)
   // Try to guess the file version
-  const fileVersion = (fileName.match(/\d+\.\d+\.\d+/) || [])[0] || null;
+  const fileVersion = (fileName.match(versionRegex) || [])[0] || null;
   let release = null;
 
   if (fileVersion) {


### PR DESCRIPTION
This will allow for downloading files marked with channel tags. Files marked with vX.X.X-{Channel} will be recognized as well as  vX.X.X-{Channel}-{Channel version}.

Ex. 
v2.1.0-beta-1
v2.1.0-beta
v2.1.0-beta-3