### PR TITLE
add download by release channel route

### DIFF
--- a/src/controllers/download.js
+++ b/src/controllers/download.js
@@ -6,6 +6,10 @@ import {getLatestRelease, getPublicDownloadUrl} from '../components/github';
 import config from '../config';
 
 export async function latest(req, res) {
+
+  const channel = req.params.channel || config.defaultChannel;
+  if (!config.channels.includes(channel)) throw new BadRequestError(`Invalid channel '${channel}'.`);
+
   const platform = req.params.platform;
   if (!['darwin', 'win32', 'linux'].includes(platform)) throw new BadRequestError(`Invalid platform '${platform}'.`);
 
@@ -18,7 +22,7 @@ export async function latest(req, res) {
     if (!['deb', 'rpm'].includes(pkg)) throw new BadRequestError(`Invalid pkg '${pkg}'.`);
   }
 
-  const latestRelease = await getLatestRelease();
+  const latestRelease = await getLatestRelease(channel);
   if (!latestRelease) throw new NotFoundError('Latest release not found.');
 
   let asset = null;

--- a/src/server.js
+++ b/src/server.js
@@ -43,6 +43,7 @@ app.get('/update/:channel/win32/:file', cache(), asyncHandler(updateCtrl.win32_f
 app.get('/update/:channel/linux', cache(), asyncHandler(updateCtrl.linux));
 app.get('/download/mirror/:mirror/latest', asyncHandler(downloadCtrl.latestMirror));
 app.get('/download/:platform/latest', cache(), asyncHandler(downloadCtrl.latest));
+app.get('/download/:platform/latest/:channel', cache(), asyncHandler(downloadCtrl.latest));
 app.get('/stats', cache(), asyncHandler(statsCtrl.main));
 app.get('/badge/:type.svg', cache(), asyncHandler(badgeCtrl.main));
 


### PR DESCRIPTION
This adds a new route where you can specify the release channel when downloading the latest version.

/download/:platform/latest/:channel