### PR TITLE
Added configuration option so that redirects are not cached.

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -44,5 +44,6 @@ export default {
   downloadsCountOffset: parseInt(process.env.DOWNLOADS_COUNT_OFFSET || '0') || 0,
   excludeDrafts: JSON.parse(process.env.EXCLUDE_DRAFTS || 'true'),
   excludePrereleases: JSON.parse(process.env.EXCLUDE_PRERELEASES || 'false'),
-  cacheTTL: '2 hours'
+  cacheTTL: '2 hours',
+  cacheIgnoreRedirects: true
 };

--- a/src/server.js
+++ b/src/server.js
@@ -30,7 +30,7 @@ if (ravenClient) {
 }
 
 // apicache does not cache headers on redirects, so do not cache if configured appropriately
-if (config.cacheIgnoreRedirects && config.cacheIgnoreRedirects == true) {
+if (config.cacheIgnoreRedirects) {
     let cacheOptions = apicache.options();
     cacheOptions.statusCodes.exclude = [301, 302];
     apicache.options(cacheOptions);

--- a/src/server.js
+++ b/src/server.js
@@ -29,6 +29,12 @@ if (ravenClient) {
   app.use(raven.middleware.express.requestHandler(ravenClient));
 }
 
+// apicache does not cache headers on redirects, so do not cache if configured appropriately
+if (config.cacheIgnoreRedirects && config.cacheIgnoreRedirects == true) {
+    let cacheOptions = apicache.options();
+    cacheOptions.statusCodes.exclude = [301, 302];
+    apicache.options(cacheOptions);
+}
 const cache = () => {
   return apicache.middleware(config.cacheTTL);
 };


### PR DESCRIPTION
Hello,

I came across a very annoying issue - which ultimately is not yours, but manifests in your server.
Specifically, apicache is not properly caching/replaying location headers when a redirect is encountered.

See attached file for traces from curl to prove this.

I have added  a config option to prevent caching redirects that prevents the problem from manifesting.

Thanks
Gareth
[squirrel-cache-error.txt](https://github.com/aluxian/squirrel-updates-server/files/1155916/squirrel-cache-error.txt)
